### PR TITLE
New medal deviations

### DIFF
--- a/index.php
+++ b/index.php
@@ -208,7 +208,7 @@ error_reporting(E_ALL);
     <hr>
     <section id="criteria">
       <h3>The criteria by which Lines may be measured</h3>
-      <p>Straightness of lines can be measured in many ways, but there are two that have been established and accepted on the GeoWizard channel: The Medals and the Burdell score.<br>The Medals are a simple standard invented by Tom Davies himself. They are scored based on the maximum deviation from the original line:<br>Platinum: 0-25m<br>Gold: 25-50m<br>Silver: 50-75m<br>Bronze: 75-100m<br>The allowed deviations were previously defined as 80m and 120m for silver and bronze respectively.</p><p>The Burdell Score is a method to score a line that is much more complex. It was created by a fan and you can read more about it on <a href="https://scoremyline.com">scoremyline.com</a>.</p>
+      <p>Straightness of lines can be measured in many ways, but there are two that have been established and accepted on the GeoWizard channel: The Medals and the Burdell score.<br>The Medals are a simple standard invented by Tom Davies himself. They are scored based on the maximum deviation from the original line:<br>Platinum: 0-25m<br>Gold: 25-50m<br>Silver: 50-75m<br>Bronze: 75-100m<br>The deviations were previously defined as 80m and 120m for silver and bronze respectively.</p><p>The Burdell Score is a method to score a line that is much more complex. It was created by a fan and you can read more about it on <a href="https://scoremyline.com">scoremyline.com</a>.</p>
     </section>
     <hr>
     <section id="mission">

--- a/index.php
+++ b/index.php
@@ -208,7 +208,7 @@ error_reporting(E_ALL);
     <hr>
     <section id="criteria">
       <h3>The criteria by which Lines may be measured</h3>
-      <p>Straightness of lines can be measured in many ways, but there are two that have been established and accepted on the GeoWizard channel: The Medals and the Burdell score.<br>The Medals are a simple standard invented by Tom Davies himself. They are scored based on the maximum deviation from the original line:<br>Platinum: 0-25m<br>Gold: 25-50m<br>Silver: 50-80m<br>Bronze: 80-120m</p><p>The Burdell Score is a method to score a line that is much more complex. It was created by a fan and you can read more about it on <a href="https://scoremyline.com">scoremyline.com</a>.</p>
+      <p>Straightness of lines can be measured in many ways, but there are two that have been established and accepted on the GeoWizard channel: The Medals and the Burdell score.<br>The Medals are a simple standard invented by Tom Davies himself. They are scored based on the maximum deviation from the original line:<br>Platinum: 0-25m<br>Gold: 25-50m<br>Silver: 50-75m<br>Bronze: 75-100m<br>The allowed deviations were previously defined as 80m and 120m for silver and bronze respectively.</p><p>The Burdell Score is a method to score a line that is much more complex. It was created by a fan and you can read more about it on <a href="https://scoremyline.com">scoremyline.com</a>.</p>
     </section>
     <hr>
     <section id="mission">

--- a/ref.txt
+++ b/ref.txt
@@ -15,11 +15,19 @@ NON-YOUTUBE
 RULE FOR AWARDS:
 	https://piped.garudalinux.org/watch?v=Jk84QaNEOFw
 	9:15
-	Deviation map:
+	Old deviation map:
 		Platinum: 0-25m
 		Gold: 25-50m
 		Silver: 50-80m
 		Bronze: 80-120m
+
+	https://youtu.be/tfjReZ9cx2c?si=cA4cHEgViGvLhAmF
+	17:59
+	New deviation map:
+		Platinum: 0-25m
+		Gold: 25-50m
+		Silver: 50-75m
+		Bronze: 75-100m
 
 MORE INFO THAT WILL BE NEEDED LATER ON FOR INFO ON MISSIONS
 	https://piped.garudalinux.org/watch?v=0tDaIw0y3j8


### PR DESCRIPTION
Tom seems to have updated the medal boundaries for silver and bronze since they were "officially" defined back in Wales 2. The latest video (England part 3) indicates a new set of equally spaced boundaries at 25m, 50m, 75m, 100m: https://www.youtube.com/watch?v=tfjReZ9cx2c&t=1079s

![image](https://github.com/SimonJoelWarkentin/straightlinewiki/assets/23644615/1150fe93-3fe4-4972-8250-776cc1f863ce)
