### PR TITLE
Fix cut off hover effect in table by removing padding from table container

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -126,6 +126,10 @@ footer {
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
 }
 
+table.container {
+    padding: 0;
+}
+
 .container2 {
 	position: absolute;
 	top: 6%;

--- a/style.css
+++ b/style.css
@@ -127,6 +127,10 @@ footer {
   box-shadow: 0 3px 10px rgba(0, 0, 0, 0.2);
 }
 
+table.container {
+    padding: 0;
+}
+
 .container2 {
 	position: absolute;
 	top: 6%;


### PR DESCRIPTION
There is the problem that when hovering over the table depending on the window size, the hover effect gets cut of on the right site.

<img width="464" height="321" alt="image" src="https://github.com/user-attachments/assets/e92718ea-3d3b-4c9e-9878-c12a34d0fce4" />

This can be fixed by removing the padding from the table container